### PR TITLE
Change the link for account settings on EBN

### DIFF
--- a/__tests__/link.test.js
+++ b/__tests__/link.test.js
@@ -16,9 +16,9 @@ describe('content script', () => {
 	it('should inject itself on account pages', async () => {
 		fixture.load('__tests__/fixtures/link.html');
 		jsdom.reconfigure({
-			url: 'https://app.easyblognetworks.com/settings/'
+			url: 'https://app.easyblognetworks.com/settings-account/'
 		});
-		expect(window.location.pathname).toEqual('/settings/');
+		expect(window.location.pathname).toEqual('/settings-account/');
 
 		await injectLink();
 
@@ -29,9 +29,9 @@ describe('content script', () => {
 	it('should have click handler', async () => {
 		fixture.load('__tests__/fixtures/link.html');
 		jsdom.reconfigure({
-			url: 'https://app.easyblognetworks.com/settings/'
+			url: 'https://app.easyblognetworks.com/settings-account/'
 		});
-		expect(window.location.pathname).toEqual('/settings/');
+		expect(window.location.pathname).toEqual('/settings-account/');
 
 		await injectLink();
 

--- a/source/link.js
+++ b/source/link.js
@@ -5,7 +5,7 @@ import select from 'select-dom';
 import OptionsSync from 'webext-options-sync';
 
 export default async function injectLink() {
-	if (document.location.href !== 'https://app.easyblognetworks.com/settings/') {
+	if (document.location.href !== 'https://app.easyblognetworks.com/settings-account/') {
 		return;
 	}
 

--- a/source/popup/root.vue
+++ b/source/popup/root.vue
@@ -34,7 +34,7 @@
 						<p class="text-muted" style="padding-top: 1rem;">Please visit the app to link this extension to your account.</p>
 					</div>
 					<div class="col-12">
-						<a href="https://app.easyblognetworks.com/settings/" target="_blank" class="btn btn-success col-12">Log In</a>
+						<a href="https://app.easyblognetworks.com/settings-account/" target="_blank" class="btn btn-success col-12">Log In</a>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
/settings page doesn't exist any more. The new one is /settings-account.
This should fix the problem where users didn't see
"Link with EBN Blog Login extension" link.

Ref: https://github.com/niteoweb/easyblognetworks/issues/51