### PR TITLE
Clear domains list on sign out

### DIFF
--- a/source/popup/root.vue
+++ b/source/popup/root.vue
@@ -149,6 +149,7 @@ export default {
 		},
 		removeAccess() {
 			new OptionsSync().setAll({});
+			this.domains = [];
 			this.linked = false;
 		}
   },


### PR DESCRIPTION
User credentials were being updated correctly but because the domains data was still synced, it was showing up even for the wrong credentials. Clearing them on sign-out solves the issue.