### PR TITLE
Remove clipboardWrite permissions

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -7,7 +7,6 @@
 	"minimum_chrome_version": "58",
 	"permissions": [
 		"storage",
-		"clipboardWrite",
 		"contextMenus",
 		"activeTab",
 		"https://app.easyblognetworks.com/*"


### PR DESCRIPTION
clipboardWrite API is deprecated and we are not using it in the extension.

For publishing the extension, a justification for each permission is required for the review.